### PR TITLE
fix: re-do time calibration every frame in case the system time shifts from PTP synchronization

### DIFF
--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -299,6 +299,14 @@ void GSCam::publish_stream()
 
   // Poll the data as fast a spossible
   while (!stop_signal_ && rclcpp::ok()) {
+
+    // First update the calibration between ros::Time and gst timestamps
+    // Note that this is only really for when PTP is used
+    GstClock * clock = gst_system_clock_obtain();
+    GstClockTime ct = gst_clock_get_time(clock);
+    gst_object_unref(clock);
+    time_offset_ = now().nanoseconds() - GST_TIME_AS_NSECONDS(ct);
+
     // This should block until a new frame is awake, this way, we'll run at the
     // actual capture framerate of the device.
     // RCLCPP_DEBUG(get_logger(), "Getting data...");

--- a/src/gscam.cpp
+++ b/src/gscam.cpp
@@ -299,7 +299,6 @@ void GSCam::publish_stream()
 
   // Poll the data as fast a spossible
   while (!stop_signal_ && rclcpp::ok()) {
-
     // First update the calibration between ros::Time and gst timestamps
     // Note that this is only really for when PTP is used
     GstClock * clock = gst_system_clock_obtain();


### PR DESCRIPTION
Problem:
- The time offset between the GST clock and ROS clock is calculated when gscam is started
- If the system clock (therefore ROS clock) is adjusted by a synchronization service after gscam is started, the time offset becomes incorrect
- This results in incorrect image timestamps

This problem was identified when starting gscam in a docker environment at startup within a service, with host clock synchronization performed using PTP.

Solution:
This PR simply performs the time offset calculation to calibrate the GST clock and ROS clock every frame. At 10Hz operation, the overhead is minimal, but it has not been tested with higher frame rates.